### PR TITLE
Configure Jest test runner

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  setupFilesAfterEnv: ['<rootDir>/tests/setup.ts']
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "live-server --port=3001 --open=index.html",
     "serve": "python -m http.server 3001",
     "build": "echo 'Frontend build complete - ready for production'",
-    "test": "echo 'Running tests...' && echo 'All tests passed ✅'",
+    "test": "jest",
     "lint": "eslint public/js/",
     "preview": "open http://localhost:3001",
     "deploy": "echo 'Ready for deployment 🚀'",
@@ -56,7 +56,9 @@
     "live-server": "^1.2.2",
     "eslint": "^8.55.0",
     "prettier": "^3.1.0",
-    "nodemon": "^3.0.2"
+    "nodemon": "^3.0.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.0"
   },
   "optionalDependencies": {
     "openai": "^4.20.1",

--- a/tests/__tests__/sample.test.ts
+++ b/tests/__tests__/sample.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, test } from '@jest/globals';
+
+describe('sample TypeScript test', () => {
+  test('adds numbers', () => {
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/tests/__tests__/tests.test.js
+++ b/tests/__tests__/tests.test.js
@@ -1,0 +1,5 @@
+const { runAllTests } = require('../../tests.js');
+
+test('runAllTests function exists', () => {
+  expect(typeof runAllTests).toBe('function');
+});


### PR DESCRIPTION
## Summary
- add Jest configuration with ts-jest preset
- create basic test files to hook into existing `tests.js`
- expose a simple TypeScript test
- update `package.json` to install Jest and run it via `npm test`

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c55b908483209a964086a7b0c656